### PR TITLE
Polyfill Array Filter ( For fix issues in IE7/8 )

### DIFF
--- a/src/jquery.email-autocomplete.js
+++ b/src/jquery.email-autocomplete.js
@@ -23,6 +23,10 @@
       if (!Array.prototype.indexOf) {
         this.doIndexOf();
       }
+      //Polyfill filter for IE
+      if (!Array.prototype.filter) {
+        this.doFilter();
+      }
 
       //get input padding,border and margin to offset text
       this.fieldLeftOffset = (this.$field.outerWidth(true) - this.$field.width()) / 2;
@@ -161,7 +165,37 @@
 
           return -1;
         };
-      }
+      },
+      
+    /**
+     * filter polyfill ( For fix issues in IE7/8 )
+     * https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/filter
+    */	  
+  	doFilter: function() {
+  	  
+  		Array.prototype.filter = function(fun /*, thisp */) {
+  			"use strict";
+  			if (this === void 0 || this === null){
+  			  throw new TypeError();
+  			}
+  			var t = Object(this);
+  			var len = t.length >>> 0;
+  			if (typeof fun !== "function"){
+  			  throw new TypeError();
+  			}
+  			var res = [];
+  			var thisp = arguments[1];
+  			for (var i = 0; i < len; i++){
+  			  if (i in t)
+  			  {
+  				var val = t[i]; // in case fun mutates this
+  				if (fun.call(thisp, val, i, t))
+  				  res.push(val);
+  			  }
+  			}
+  			return res;
+  		};
+  	}
   };
 
   $.fn[pluginName] = function (options) {


### PR DESCRIPTION
I found the auto-complete function cannot work in IE7/8 becuase the array filter is not supported.
So I add doFilter function to fix this issue.
REF: https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/filter
